### PR TITLE
Add support for Apollo's gql template literal

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/injection/JSGraphQLLanguageInjectionUtil.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/injection/JSGraphQLLanguageInjectionUtil.java
@@ -22,6 +22,7 @@ public class JSGraphQLLanguageInjectionUtil {
 
     public static final String RELAY_QL_TEMPLATE_TAG = "Relay.QL";
     public static final String GRAPHQL_TEMPLATE_TAG = "graphql";
+    public static final String APOLLO_GQL_TEMPLATE_TAG = "gql";
 
     public enum JSGraphQLInjectionTag {
         RelayQL,
@@ -49,7 +50,7 @@ public class JSGraphQLLanguageInjectionUtil {
             final PsiElement firstChild = template.getFirstChild();
             if (firstChild instanceof JSReferenceExpression) {
                 final String tagText = firstChild.getText();
-                if (RELAY_QL_TEMPLATE_TAG.equals(tagText) || GRAPHQL_TEMPLATE_TAG.equals(tagText)) {
+                if (RELAY_QL_TEMPLATE_TAG.equals(tagText) || GRAPHQL_TEMPLATE_TAG.equals(tagText) || APOLLO_GQL_TEMPLATE_TAG.equals(tagText)) {
                     if(tagRef != null) {
                         tagRef.set(RELAY_QL_TEMPLATE_TAG.equals(tagText) ? JSGraphQLInjectionTag.RelayQL : JSGraphQLInjectionTag.GraphQL);
                     }


### PR DESCRIPTION
Apollo (http://www.apollostack.com/) currently uses a 'gql' template literal. Importing as 'graphql' is not really an option as the main React integration already exposes a named export with that name.