### PR TITLE
Add extra note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Download [graphql.config.json](https://github.com/jimkyndemeyer/js-graphql-intel
 
 Make sure you've edited your `graphql.config.json` to point it at your schema. This enables the plugin to properly recognize the available types and their fields.
 
+Make sure both the schema "file" or "url" and the endpoints "url" are correct.
+
 **Which IDEs are compatible with the plugin?**
 
 The plugin is compatible with version 143+ of IntelliJ IDEA, WebStorm, RubyMine, PhpStorm, and PyCharm.


### PR DESCRIPTION
This one caught me out, it was odd because the fields were marked as not being valid, yet ctrl+click worked - turned out my endpoints url was incorrect which caused it.

Quick question as well, is it possible to for specific projects only enable syntax highlighting from this plugin?