### PR TITLE
fix leaking tree and editor

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/project/schemastatus/GraphQLSchemasPanel.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/schemastatus/GraphQLSchemasPanel.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.DumbServiceImpl;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.SideBorder;
 import com.intellij.ui.components.JBScrollPane;
@@ -88,6 +89,7 @@ public class GraphQLSchemasPanel extends JPanel {
         SimpleTreeStructure.Impl treeStructure = new SimpleTreeStructure.Impl(new GraphQLSchemasRootNode(myProject));
         DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultMutableTreeNode());
         SimpleTreeBuilder myBuilder = new SimpleTreeBuilder(myTree, treeModel, treeStructure, IndexComparator.INSTANCE);
+        Disposer.register(myProject, myBuilder);
 
         // debounce tree updates to prevent perf-hit
         final Alarm treeUpdaterAlarm = AlarmFactory.getInstance().create();

--- a/src/main/com/intellij/lang/jsgraphql/v1/ide/project/JSGraphQLLanguageUIProjectService.java
+++ b/src/main/com/intellij/lang/jsgraphql/v1/ide/project/JSGraphQLLanguageUIProjectService.java
@@ -592,9 +592,9 @@ public class JSGraphQLLanguageUIProjectService implements Disposable, FileEditor
 
         final ContentImpl content = new ContentImpl(fileEditor.getComponent(), "Query result", true);
         content.setCloseable(false);
+        content.setShouldDisposeContent(false);
         toolWindow.getContentManager().addContent(content);
-
-
+        Disposer.register(content, fileEditor);
     }
 
     private void initToolWindow() {


### PR DESCRIPTION
```
2019-03-20 13:53:10,368 [ 269250]  ERROR - api.util.objectTree.ObjectTree - Memory leak detected: 'com.intellij.ui.treeStructure.SimpleTreeBuilder@1cc79221' of class com.intellij.ui.treeStructure.SimpleTreeBuilder
See the cause for the corresponding Disposer.register() stacktrace:
 
java.lang.RuntimeException: Memory leak detected: 'com.intellij.ui.treeStructure.SimpleTreeBuilder@1cc79221' of class com.intellij.ui.treeStructure.SimpleTreeBuilder
See the cause for the corresponding Disposer.register() stacktrace:
    at com.intellij.openapi.util.objectTree.ObjectTree.assertIsEmpty(ObjectTree.java:256)
    at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:142)
    at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:138)
    at com.intellij.openapi.application.impl.ApplicationImpl.disposeSelf(ApplicationImpl.java:251)
    at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:815)
    at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:790)
    at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:779)
    at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:775)
    at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:742)
    at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:737)
    at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$null$3(MacOSApplicationProvider.java:107)
    at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$submit$7(MacOSApplicationProvider.java:177)
    at com.intellij.openapi.application.TransactionGuardImpl.runSyncTransaction(TransactionGuardImpl.java:88)
    at com.intellij.openapi.application.TransactionGuardImpl.lambda$pollQueueLater$0(TransactionGuardImpl.java:74)
    at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:435)
    at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:419)
    at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:403)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:764)
    at java.awt.EventQueue.access$500(EventQueue.java:98)
    at java.awt.EventQueue$3.run(EventQueue.java:715)
    at java.awt.EventQueue$3.run(EventQueue.java:709)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:734)
    at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:723)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:672)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:367)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.Throwable
    at com.intellij.openapi.util.objectTree.ObjectNode.<init>(ObjectNode.java:54)
    at com.intellij.openapi.util.objectTree.ObjectTree.createNodeFor(ObjectTree.java:128)
    at com.intellij.openapi.util.objectTree.ObjectTree.register(ObjectTree.java:90)
    at com.intellij.openapi.util.Disposer.register(Disposer.java:97)
    at com.intellij.openapi.util.Disposer.register(Disposer.java:93)
    at com.intellij.ide.util.treeView.AbstractTreeUi.init(AbstractTreeUi.java:241)
    at com.intellij.ide.util.treeView.AbstractTreeBuilder.init(AbstractTreeBuilder.java:67)
    at com.intellij.ide.util.treeView.AbstractTreeBuilder.<init>(AbstractTreeBuilder.java:51)
    at com.intellij.ide.util.treeView.AbstractTreeBuilder.<init>(AbstractTreeBuilder.java:43)
    at com.intellij.ui.treeStructure.SimpleTreeBuilder.<init>(SimpleTreeBuilder.java:33)
    at com.intellij.lang.jsgraphql.ide.project.schemastatus.GraphQLSchemasPanel.createTreePanel(GraphQLSchemasPanel.java:90)
    at com.intellij.lang.jsgraphql.ide.project.schemastatus.GraphQLSchemasPanel.<init>(GraphQLSchemasPanel.java:58)
    at com.intellij.lang.jsgraphql.v1.ide.project.toolwindow.JSGraphQLLanguageToolWindowManager.createSchemasPanel(JSGraphQLLanguageToolWindowManager.java:72)
    at com.intellij.lang.jsgraphql.v1.ide.project.toolwindow.JSGraphQLLanguageToolWindowManager.init(JSGraphQLLanguageToolWindowManager.java:63)
    at com.intellij.lang.jsgraphql.v1.ide.project.JSGraphQLLanguageUIProjectService.lambda$null$8(JSGraphQLLanguageUIProjectService.java:605)
    at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
```