### PR TITLE
Normalizing schema editor line breaks.

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionService.java
@@ -364,8 +364,10 @@ public class GraphQLIntrospectionService implements Disposable {
 
     private void setEditorTextAndFormatLines(String text, FileEditor fileEditor) {
         if (fileEditor instanceof TextEditor) {
+            // IntelliJ only allows the \n linebreak inside editor documents.
+            final String normalizedText = StringUtil.convertLineSeparators(text);
             final Editor editor = ((TextEditor) fileEditor).getEditor();
-            editor.getDocument().setText(text);
+            editor.getDocument().setText(normalizedText);
             AnAction reformatCode = ActionManager.getInstance().getAction("ReformatCode");
             if (reformatCode != null) {
                 final AnActionEvent actionEvent = AnActionEvent.createFromDataContext(


### PR DESCRIPTION
Addresses the issue https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/issues/347

The IDE requires that only `\n` be used when setting document text, it seems during a GraphQL library update, different line breaks were introduced along with the schema printer.