### PR TITLE
Introspection messages refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ trim_trailing_whitespace = false
 
 [{*.bnf, *.flex}]
 indent_size = 2
+
+[*.xml]
+indent_size = 2

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,6 +29,8 @@
   <depends optional="true" config-file="graphql-javascript.xml">JavaScript</depends>
   <depends optional="true" config-file="graphql-intellilang.xml">org.intellij.intelliLang</depends>
 
+  <resource-bundle>messages.GraphQLMessages</resource-bundle>
+
   <extensionPoints>
     <extensionPoint name="graphQLFindUsagesFileTypeContributor" interface="com.intellij.lang.jsgraphql.ide.references.GraphQLFindUsagesFileTypeContributor" />
   </extensionPoints>
@@ -53,7 +55,7 @@
     <projectService serviceInterface="com.intellij.lang.jsgraphql.v1.ide.project.JSGraphQLLanguageUIProjectService" serviceImplementation="com.intellij.lang.jsgraphql.v1.ide.project.JSGraphQLLanguageUIProjectService" />
     <projectService serviceInterface="com.intellij.lang.jsgraphql.GraphQLSettings" serviceImplementation="com.intellij.lang.jsgraphql.GraphQLSettings" />
     <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManager" serviceImplementation="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManager" />
-    <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionHelper" serviceImplementation="com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionHelper" />
+    <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService" serviceImplementation="com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService" />
     <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigGlobMatcher" serviceImplementation="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigGlobMatcherImpl" />
     <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.GraphQLRelayModernAnnotationFilter" serviceImplementation="com.intellij.lang.jsgraphql.ide.GraphQLRelayModernAnnotationFilter" />
 

--- a/resources/messages/GraphQLMessages.properties
+++ b/resources/messages/GraphQLMessages.properties
@@ -1,0 +1,22 @@
+# Notifications
+graphql.notification.introspection.error.title=GraphQL introspection error
+graphql.notification.introspection.error.body=A valid schema could not be built using the introspection result.<br/>Error: {0}
+graphql.notification.introspection.spec.error.body=A valid schema could not be built using the introspection result. The endpoint may not follow the GraphQL Specification.<br/>Error: {0}
+graphql.notification.error.title=GraphQL error
+graphql.notification.response=Response
+graphql.notification.stack.trace=Stack trace
+graphql.notification.retry.without.defaults=Retry (skip default values from now on)
+graphql.notification.retry=Retry
+graphql.notification.unable.to.open.editor=Unable to open an editor for '{0}'
+graphql.notification.unable.to.create.file=Unable to create file '{0}' in directory '{1}'.<br/>Error: {2}
+graphql.notification.invalid.config.file=Invalid config file
+graphql.notification.empty.schema.path=Please set a non-empty `schemaPath` field in the config file.
+graphql.notification.empty.endpoint.url=Please set a non-empty endpoint `url` field in the config file.
+
+# Introspection
+graphql.introspection.missing.data=Expected `data` key to be present in query result.
+graphql.introspection.missing.schema=Expected `__schema` key to be present in query result data.
+graphql.introspection.errors=Introspection query returned errors: {0}
+
+# Progress
+graphql.progress.executing.introspection.query=Executing GraphQL introspection query

--- a/src/main/com/intellij/lang/jsgraphql/GraphQLBundle.java
+++ b/src/main/com/intellij/lang/jsgraphql/GraphQLBundle.java
@@ -1,0 +1,23 @@
+package com.intellij.lang.jsgraphql;
+
+import com.intellij.DynamicBundle;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.PropertyKey;
+
+public class GraphQLBundle extends DynamicBundle {
+    @NonNls
+    public static final String PATH = "messages.GraphQLMessages";
+
+    private static final GraphQLBundle INSTANCE = new GraphQLBundle();
+
+    private GraphQLBundle() {
+        super(PATH);
+    }
+
+    @NotNull
+    public static @Nls String message(@NotNull @PropertyKey(resourceBundle = PATH) String key, Object @NotNull ... params) {
+        return INSTANCE.getMessage(key, params);
+    }
+}

--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionJsonToSDLLineMarkerProvider.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionJsonToSDLLineMarkerProvider.java
@@ -31,9 +31,6 @@ import graphql.GraphQLException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.List;
-
 /**
  * Line marker which shows an action to turn a GraphQL Introspection JSON result into a GraphQL schema expressed in GraphQL SDL.
  */
@@ -57,17 +54,17 @@ public class GraphQLIntrospectionJsonToSDLLineMarkerProvider implements LineMark
                     for (JsonProperty property : ((JsonObject) jsonProperty.getValue()).getPropertyList()) {
                         if ("types".equals(property.getName()) && property.getValue() instanceof JsonArray) {
                             // likely a GraphQL schema with a { __schema: { types: [] } }
-                            final GraphQLIntrospectionHelper graphQLIntrospectionHelper = GraphQLIntrospectionHelper.getService(project);
+                            final GraphQLIntrospectionService graphQLIntrospectionService = GraphQLIntrospectionService.getInstance(project);
                             final Ref<Runnable> generateAction = Ref.create();
                             generateAction.set(() -> {
                                 try {
                                     final String introspectionJson = element.getContainingFile().getText();
-                                    final String schemaAsSDL = graphQLIntrospectionHelper.printIntrospectionJsonAsGraphQL(introspectionJson);
+                                    final String schemaAsSDL = graphQLIntrospectionService.printIntrospectionJsonAsGraphQL(introspectionJson);
 
                                     final VirtualFile jsonFile = element.getContainingFile().getVirtualFile();
                                     final String outputFileName = jsonFile.getName() + ".graphql";
 
-                                    graphQLIntrospectionHelper.createOrUpdateIntrospectionOutputFile(schemaAsSDL, GraphQLIntrospectionHelper.IntrospectionOutputFormat.SDL, jsonFile, outputFileName);
+                                    graphQLIntrospectionService.createOrUpdateIntrospectionOutputFile(schemaAsSDL, GraphQLIntrospectionService.IntrospectionOutputFormat.SDL, jsonFile, outputFileName);
 
                                 } catch (Exception e) {
                                     Notification notification = new Notification("GraphQL", "Unable to create GraphQL SDL", e.getMessage(), NotificationType.ERROR);
@@ -88,7 +85,7 @@ public class GraphQLIntrospectionJsonToSDLLineMarkerProvider implements LineMark
                                             notification.addAction(retryWithoutDefaultValues);
                                         }
                                     }
-                                    graphQLIntrospectionHelper.addIntrospectionStackTraceAction(notification, e);
+                                    graphQLIntrospectionService.addIntrospectionStackTraceAction(notification, e);
                                     Notifications.Bus.notify(notification.setImportant(true));
                                 }
                             });

--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLRerunLatestIntrospectionAction.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLRerunLatestIntrospectionAction.java
@@ -13,7 +13,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 
 public class GraphQLRerunLatestIntrospectionAction extends AnAction {
 
-    private static final String TEXT = "Update the local schema by re-running the latest introspection query";
+    private static final String TEXT = "Update the Local Schema by Running Introspection Query";
 
     public GraphQLRerunLatestIntrospectionAction() {
         super(TEXT, "Re-runs the latest introspection query that was performed to update the local schema, e.g. when a remote schema has been changed", AllIcons.Actions.Rerun);
@@ -25,7 +25,7 @@ public class GraphQLRerunLatestIntrospectionAction extends AnAction {
         boolean enabled = false;
         e.getPresentation().setText(TEXT);
         if (e.getProject() != null) {
-            final GraphQLIntrospectionTask latestIntrospection = GraphQLIntrospectionHelper.getService(e.getProject()).getLatestIntrospection();
+            final GraphQLIntrospectionTask latestIntrospection = GraphQLIntrospectionService.getInstance(e.getProject()).getLatestIntrospection();
             if (latestIntrospection != null) {
                 enabled = true;
                 e.getPresentation().setText(TEXT + " (" + latestIntrospection.getEndpoint().getName() + ")");
@@ -37,7 +37,7 @@ public class GraphQLRerunLatestIntrospectionAction extends AnAction {
     @Override
     public void actionPerformed(AnActionEvent e) {
         if (e.getProject() != null) {
-            GraphQLIntrospectionTask latestIntrospection = GraphQLIntrospectionHelper.getService(e.getProject()).getLatestIntrospection();
+            GraphQLIntrospectionTask latestIntrospection = GraphQLIntrospectionService.getInstance(e.getProject()).getLatestIntrospection();
             if (latestIntrospection != null) {
                 latestIntrospection.getRunnable().run();
             }

--- a/src/main/com/intellij/lang/jsgraphql/ide/notifications/GraphQLNotificationUtil.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/notifications/GraphQLNotificationUtil.java
@@ -1,0 +1,61 @@
+package com.intellij.lang.jsgraphql.ide.notifications;
+
+import com.intellij.lang.jsgraphql.GraphQLBundle;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationAction;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.ObjectUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GraphQLNotificationUtil {
+    public static final String NOTIFICATION_GROUP_ID = "GraphQL";
+
+    public static void showInvalidConfigurationNotification(@NotNull String message,
+                                                            @Nullable VirtualFile introspectionSourceFile,
+                                                            @NotNull Project project) {
+        Notification notification = new Notification(
+            NOTIFICATION_GROUP_ID,
+            GraphQLBundle.message("graphql.notification.invalid.config.file"),
+            message,
+            NotificationType.WARNING
+        );
+
+        if (introspectionSourceFile != null) {
+            notification.addAction(new NotificationAction(introspectionSourceFile.getName()) {
+                @Override
+                public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
+                    FileEditorManager.getInstance(project).openFile(introspectionSourceFile, true);
+                }
+            });
+        }
+
+        Notifications.Bus.notify(notification);
+    }
+
+    public static void showRequestExceptionNotification(@NotNull NotificationAction retry,
+                                                        @NotNull String url,
+                                                        @NotNull String error,
+                                                        @NotNull NotificationType notificationType,
+                                                        @NotNull Project project) {
+        Notifications.Bus.notify(
+            new Notification(
+                NOTIFICATION_GROUP_ID,
+                GraphQLBundle.message("graphql.notification.error.title"),
+                url + ": " + error,
+                notificationType
+            ).addAction(retry),
+            project
+        );
+    }
+
+    public static String formatExceptionMessage(@NotNull Exception exception) {
+        return StringUtil.decapitalize(ObjectUtils.coalesce(exception.getMessage(), ""));
+    }
+}

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -21,7 +21,7 @@ import com.intellij.json.JsonFileType;
 import com.intellij.lang.jsgraphql.GraphQLFileType;
 import com.intellij.lang.jsgraphql.GraphQLLanguage;
 import com.intellij.lang.jsgraphql.endpoint.JSGraphQLEndpointFileType;
-import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionHelper;
+import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigData;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLResolvedConfigData;
@@ -693,7 +693,7 @@ public class GraphQLConfigManager {
                             introspect.addAction(new NotificationAction("Introspect '" + endpoint.url + "'") {
                                 @Override
                                 public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
-                                    GraphQLIntrospectionHelper.getService(myProject).performIntrospectionQueryAndUpdateSchemaPathFile(myProject, endpoint);
+                                    GraphQLIntrospectionService.getInstance(myProject).performIntrospectionQueryAndUpdateSchemaPathFile(myProject, endpoint);
                                 }
                             });
                             String schemaFilePath = endpoint.configPackageSet.getSchemaFilePath();

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/schemastatus/GraphQLSchemaEndpointsListNode.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/schemastatus/GraphQLSchemaEndpointsListNode.java
@@ -11,7 +11,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.scratch.ScratchRootType;
 import com.intellij.lang.jsgraphql.GraphQLLanguage;
 import com.intellij.lang.jsgraphql.icons.JSGraphQLIcons;
-import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionHelper;
+import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
 import com.intellij.lang.jsgraphql.v1.ide.endpoints.JSGraphQLEndpointsModel;
 import com.intellij.openapi.fileEditor.FileEditor;
@@ -93,7 +93,7 @@ public class GraphQLSchemaEndpointsListNode extends CachingSimpleNode {
                 public PopupStep onChosen(String selectedValue, boolean finalChoice) {
                     return doFinalStep(() -> {
                         if (introspect.equals(selectedValue)) {
-                            GraphQLIntrospectionHelper.getService(myProject).performIntrospectionQueryAndUpdateSchemaPathFile(myProject, endpoint);
+                            GraphQLIntrospectionService.getInstance(myProject).performIntrospectionQueryAndUpdateSchemaPathFile(myProject, endpoint);
                         } else if (createScratch.equals(selectedValue)) {
                             final String configBaseDir = endpoint.configPackageSet.getConfigBaseDir().getPresentableUrl();
                             final String text = "# " + GRAPHQLCONFIG_COMMENT + configBaseDir + "!" + Optional.ofNullable(projectKey).orElse("") + "\n\nquery ScratchQuery {\n\n}";

--- a/src/main/com/intellij/lang/jsgraphql/schema/SchemaIDLTypeDefinitionRegistry.java
+++ b/src/main/com/intellij/lang/jsgraphql/schema/SchemaIDLTypeDefinitionRegistry.java
@@ -13,7 +13,7 @@ import com.intellij.json.JsonFileType;
 import com.intellij.lang.jsgraphql.GraphQLFileType;
 import com.intellij.lang.jsgraphql.GraphQLLanguage;
 import com.intellij.lang.jsgraphql.endpoint.ide.project.JSGraphQLEndpointNamedTypeRegistry;
-import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionHelper;
+import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService;
 import com.intellij.lang.jsgraphql.ide.project.GraphQLInjectionSearchHelper;
 import com.intellij.lang.jsgraphql.ide.project.GraphQLPsiSearchHelper;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManager;
@@ -230,7 +230,7 @@ public class SchemaIDLTypeDefinitionRegistry {
                     if (psiFile != null) {
                         try {
                             synchronized (GRAPHQL_INTROSPECTION_JSON_TO_SDL) {
-                                final String introspectionJsonAsGraphQL = GraphQLIntrospectionHelper.getService(project).printIntrospectionJsonAsGraphQL(psiFile.getText());
+                                final String introspectionJsonAsGraphQL = GraphQLIntrospectionService.getInstance(project).printIntrospectionJsonAsGraphQL(psiFile.getText());
                                 final GraphQLFile currentSDLPsiFile = psiFile.getUserData(GRAPHQL_INTROSPECTION_JSON_TO_SDL);
                                 if (currentSDLPsiFile != null && currentSDLPsiFile.getText().equals(introspectionJsonAsGraphQL)) {
                                     // already have a PSI file that matches the introspection SDL

--- a/src/test/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionServiceTest.java
+++ b/src/test/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionServiceTest.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
-public class GraphQLIntrospectionHelperTest extends BasePlatformTestCase {
+public class GraphQLIntrospectionServiceTest extends BasePlatformTestCase {
 
     @Override
     protected String getTestDataPath() {
@@ -21,7 +21,7 @@ public class GraphQLIntrospectionHelperTest extends BasePlatformTestCase {
     private void doTest(@NotNull String source, @NotNull String expected) {
         myFixture.configureByText(
                 "result.graphql",
-                new GraphQLIntrospectionHelper(getProject()).printIntrospectionJsonAsGraphQL(readSchemaJson(source))
+                new GraphQLIntrospectionService(getProject()).printIntrospectionJsonAsGraphQL(readSchemaJson(source))
         );
         myFixture.checkResultByFile(expected);
     }


### PR DESCRIPTION
1. Made it possible to open the result of an introspection request from a notification. It is useful to view additional information, such as the missing auth token.
2. Extracted text strings to the bundle, unified similar messages.
3. Fixed an issue when the schema URL is null before the introspection request. Caused NPE.
4. Fixed missing parent disposable in project service.
5. Fixed string capitalization.