### PR TITLE
Reworked introspection query error handling

### DIFF
--- a/resources/messages/GraphQLMessages.properties
+++ b/resources/messages/GraphQLMessages.properties
@@ -1,9 +1,10 @@
 # Notifications
-graphql.notification.introspection.error.title=GraphQL introspection error
+graphql.notification.introspection.error.title=GraphQL introspection
 graphql.notification.introspection.error.body=A valid schema could not be built using the introspection result.<br/>Error: {0}
 graphql.notification.introspection.spec.error.body=A valid schema could not be built using the introspection result. The endpoint may not follow the GraphQL Specification.<br/>Error: {0}
+graphql.notification.introspection.parse.error=The server introspection response cannot be parsed as a valid JSON object.
+graphql.notification.introspection.empty.errors=Encountered empty error array, which does not conform to the GraphQL spec.
 graphql.notification.error.title=GraphQL error
-graphql.notification.response=Response
 graphql.notification.stack.trace=Stack trace
 graphql.notification.retry.without.defaults=Retry (skip default values from now on)
 graphql.notification.retry=Retry

--- a/resources/messages/GraphQLMessages.properties
+++ b/resources/messages/GraphQLMessages.properties
@@ -8,15 +8,15 @@ graphql.notification.error.title=GraphQL error
 graphql.notification.stack.trace=Stack trace
 graphql.notification.retry.without.defaults=Retry (skip default values from now on)
 graphql.notification.retry=Retry
-graphql.notification.unable.to.open.editor=Unable to open an editor for '{0}'
-graphql.notification.unable.to.create.file=Unable to create file '{0}' in directory '{1}'.<br/>Error: {2}
+graphql.notification.unable.to.open.editor=Unable to open an editor for ''{0}''
+graphql.notification.unable.to.create.file=Unable to create file ''{0}'' in directory ''{1}''.<br/>Error: {2}
 graphql.notification.invalid.config.file=Invalid config file
 graphql.notification.empty.schema.path=Please set a non-empty `schemaPath` field in the config file.
 graphql.notification.empty.endpoint.url=Please set a non-empty endpoint `url` field in the config file.
 graphql.notification.unable.to.parse.file=Unable to parse {0}
 graphql.notification.load.schema.from.endpoint.title=Get GraphQL schema from endpoint now?
-graphql.notification.load.schema.from.endpoint.body=Introspect '{0}' to update the local schema file.
-graphql.notification.load.schema.from.endpoint.action=Introspect '{0}'
+graphql.notification.load.schema.from.endpoint.body=Introspect ''{0}'' to update the local schema file.
+graphql.notification.load.schema.from.endpoint.action=Introspect ''{0}''
 
 # Introspection
 graphql.introspection.missing.data=Expected `data` key to be present in query result.

--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionJsonToSDLLineMarkerProvider.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionJsonToSDLLineMarkerProvider.java
@@ -65,7 +65,7 @@ public class GraphQLIntrospectionJsonToSDLLineMarkerProvider implements LineMark
                 generateAction.set(() -> {
                     try {
                         final String introspectionJson = element.getContainingFile().getText();
-                        final String schemaAsSDL = graphQLIntrospectionService.printIntrospectionJsonAsGraphQL(introspectionJson);
+                        final String schemaAsSDL = graphQLIntrospectionService.printIntrospectionAsGraphQL(introspectionJson);
 
                         final VirtualFile jsonFile = element.getContainingFile().getVirtualFile();
                         final String outputFileName = jsonFile.getName() + ".graphql";

--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionService.java
@@ -9,10 +9,10 @@ package com.intellij.lang.jsgraphql.ide.editor;
 
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.ide.actions.CreateFileAction;
 import com.intellij.ide.impl.DataManagerImpl;
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.json.JsonLanguage;
 import com.intellij.lang.jsgraphql.GraphQLBundle;
 import com.intellij.lang.jsgraphql.GraphQLSettings;
 import com.intellij.lang.jsgraphql.ide.notifications.GraphQLNotificationUtil;
@@ -31,6 +31,7 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorBundle;
@@ -151,7 +152,7 @@ public class GraphQLIntrospectionService implements Disposable {
             Task.Backgroundable task = new IntrospectionQueryTask(method, schemaPath, introspectionSourceFile, retry, graphQLSettings, endpoint, url);
             ProgressManager.getInstance().run(task);
         } catch (UnsupportedEncodingException | IllegalStateException | IllegalArgumentException e) {
-            GraphQLNotificationUtil.showRequestExceptionNotification(retry, url, GraphQLNotificationUtil.formatExceptionMessage(e), NotificationType.ERROR, myProject);
+            GraphQLNotificationUtil.showGraphQLRequestErrorNotification(retry, url, e, NotificationType.ERROR, myProject);
         }
     }
 
@@ -167,64 +168,32 @@ public class GraphQLIntrospectionService implements Disposable {
         });
     }
 
-    public void addShowResponseTextAction(@NotNull Notification notification, @Nullable String responseText) {
-        if (StringUtil.isEmptyOrSpaces(responseText)) return;
-
-        notification.addAction(new NotificationAction(GraphQLBundle.message("graphql.notification.response")) {
-            @Override
-            public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
-                PsiFile file = PsiFileFactory.getInstance(myProject)
-                    .createFileFromText("response.json", JsonLanguage.INSTANCE, responseText);
-                new OpenFileDescriptor(myProject, file.getVirtualFile()).navigate(true);
-            }
-        });
-    }
-
     /**
      * Ensures that the JSON response falls within the GraphQL specification character range such that it can be expressed as valid GraphQL SDL in the editor
      *
      * @param introspectionJson the JSON to sanitize
      * @return a sanitized version where the character ranges are within those allowed by the GraphQL Language Specification
      */
-    private String sanitizeIntrospectionJson(@NotNull String introspectionJson) {
+    private static String sanitizeIntrospectionJson(@NotNull String introspectionJson) {
         // Strip out emojis (e.g. the one in the GitHub schema) since they're outside the allowed range
         return introspectionJson.replaceAll("[\ud83c\udf00-\ud83d\ude4f]|[\ud83d\ude80-\ud83d\udeff]", "");
     }
 
     @SuppressWarnings("unchecked")
-    public String printIntrospectionJsonAsGraphQL(@NotNull String introspectionJson) {
-        Map<String, Object> introspectionAsMap = new Gson().fromJson(sanitizeIntrospectionJson(introspectionJson), Map.class);
-        if (!introspectionAsMap.containsKey("__schema")) {
-            // possibly a full query result
-            if (introspectionAsMap.containsKey("errors")) {
-                final Object errorsValue = introspectionAsMap.get("errors");
-                if (errorsValue instanceof List && ((List<?>) errorsValue).size() == 0) {
-                    if (!PropertiesComponent.getInstance().isTrueValue(DISABLE_EMPTY_ERRORS_WARNING_KEY)) {
-                        final Notification emptyErrorNotification = new Notification("GraphQL", "GraphQL Configuration Warning", "Encountered empty error array, which does not conform to the GraphQL spec.", NotificationType.WARNING);
+    @NotNull
+    public static Map<String, Object> parseIntrospectionJson(@NotNull String introspectionJson) {
+        return new Gson().fromJson(sanitizeIntrospectionJson(introspectionJson), Map.class);
+    }
 
-                        final AnAction dontShowAgainAction = new NotificationAction(EditorBundle.message("notification.dont.show.again.message")) {
-                            @Override
-                            public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
-                                PropertiesComponent.getInstance().setValue(DISABLE_EMPTY_ERRORS_WARNING_KEY, "true");
-                                notification.hideBalloon();
-                            }
-                        };
+    @NotNull
+    public String printIntrospectionAsGraphQL(@NotNull String introspectionJson) {
+        return printIntrospectionAsGraphQL(parseIntrospectionJson(introspectionJson));
+    }
 
-                        emptyErrorNotification.addAction(dontShowAgainAction);
-                        Notifications.Bus.notify(emptyErrorNotification, myProject);
-                    }
-                } else {
-                    throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.errors", new Gson().toJson(introspectionAsMap.get("errors"))));
-                }
-            }
-            if (!introspectionAsMap.containsKey("data")) {
-                throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.missing.data"));
-            }
-            introspectionAsMap = (Map<String, Object>) introspectionAsMap.get("data");
-            if (!introspectionAsMap.containsKey("__schema")) {
-                throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.missing.schema"));
-            }
-        }
+    @SuppressWarnings("unchecked")
+    @NotNull
+    public String printIntrospectionAsGraphQL(@NotNull Map<String, Object> introspection) {
+        introspection = getIntrospectionSchemaData(introspection);
 
         if (!GraphQLSettings.getSettings(myProject).isEnableIntrospectionDefaultValues()) {
             // strip out the defaultValues that are potentially non-spec compliant
@@ -237,10 +206,10 @@ public class GraphQLIntrospectionService implements Disposable {
                     ((Map) value).values().forEach(mapValue -> defaultValueVisitJson.get().consume(mapValue));
                 }
             });
-            defaultValueVisitJson.get().consume(introspectionAsMap);
+            defaultValueVisitJson.get().consume(introspection);
         }
 
-        final Document schemaDefinition = new GraphQLIntrospectionResultToSchema().createSchemaDefinition(introspectionAsMap);
+        final Document schemaDefinition = new GraphQLIntrospectionResultToSchema().createSchemaDefinition(introspection);
         final SchemaPrinter.Options options = SchemaPrinter.Options
             .defaultOptions()
             .includeScalarTypes(false)
@@ -271,6 +240,48 @@ public class GraphQLIntrospectionService implements Disposable {
             }
         }
         return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    private Map<String, Object> getIntrospectionSchemaData(@NotNull Map<String, Object> introspection) {
+        if (!introspection.containsKey("__schema")) {
+            // possibly a full query result
+            if (introspection.containsKey("errors")) {
+                final Object errorsValue = introspection.get("errors");
+                if (errorsValue instanceof List && ((List<?>) errorsValue).size() == 0) {
+                    if (!PropertiesComponent.getInstance().isTrueValue(DISABLE_EMPTY_ERRORS_WARNING_KEY)) {
+                        final Notification emptyErrorNotification = new Notification(
+                            GraphQLNotificationUtil.NOTIFICATION_GROUP_ID,
+                            GraphQLBundle.message("graphql.notification.introspection.error.title"),
+                            GraphQLBundle.message("graphql.notification.introspection.empty.errors"),
+                            NotificationType.WARNING
+                        );
+
+                        final AnAction dontShowAgainAction = new NotificationAction(EditorBundle.message("notification.dont.show.again.message")) {
+                            @Override
+                            public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
+                                PropertiesComponent.getInstance().setValue(DISABLE_EMPTY_ERRORS_WARNING_KEY, "true");
+                                notification.hideBalloon();
+                            }
+                        };
+
+                        emptyErrorNotification.addAction(dontShowAgainAction);
+                        Notifications.Bus.notify(emptyErrorNotification, myProject);
+                    }
+                } else {
+                    throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.errors", new Gson().toJson(introspection.get("errors"))));
+                }
+            }
+            if (!introspection.containsKey("data")) {
+                throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.missing.data"));
+            }
+            introspection = (Map<String, Object>) introspection.get("data");
+            if (!introspection.containsKey("__schema")) {
+                throw new IllegalArgumentException(GraphQLBundle.message("graphql.introspection.missing.schema"));
+            }
+        }
+        return introspection;
     }
 
     private GraphQLSchema buildIntrospectionSchema(TypeDefinitionRegistry registry) {
@@ -325,11 +336,11 @@ public class GraphQLIntrospectionService implements Disposable {
         SDL
     }
 
-    void createOrUpdateIntrospectionOutputFile(String schemaText,
-                                               IntrospectionOutputFormat format,
-                                               VirtualFile introspectionSourceFile,
-                                               String outputFileName) {
-        ApplicationManager.getApplication().runWriteAction(() -> {
+    void createOrUpdateIntrospectionOutputFile(@NotNull String schemaText,
+                                               @NotNull IntrospectionOutputFormat format,
+                                               @NotNull VirtualFile introspectionSourceFile,
+                                               @NotNull String outputFileName) {
+        WriteAction.run(() -> {
             try {
                 final String header;
                 switch (format) {
@@ -422,37 +433,74 @@ public class GraphQLIntrospectionService implements Disposable {
         @Override
         public void run(@NotNull ProgressIndicator indicator) {
             indicator.setIndeterminate(true);
+            String responseJson;
+
             try {
                 HttpClient httpClient = new HttpClient(new HttpClientParams());
                 httpClient.executeMethod(method);
-                final String responseJson = ObjectUtils.coalesce(method.getResponseBodyAsString(), "");
-                ApplicationManager.getApplication().invokeLater(() -> {
-                    try {
-                        JSGraphQLLanguageUIProjectService.getService(myProject).showQueryResult(responseJson, JSGraphQLLanguageUIProjectService.QueryResultDisplay.ON_ERRORS_ONLY);
-                        IntrospectionOutputFormat format = schemaPath.endsWith(".json") ? IntrospectionOutputFormat.JSON : IntrospectionOutputFormat.SDL;
-                        // always try to print the schema to validate it since that will be done in schema discovery of the JSON anyway
-                        final String schemaAsSDL = printIntrospectionJsonAsGraphQL(responseJson);
-                        final String schemaText = format == IntrospectionOutputFormat.SDL ? schemaAsSDL : responseJson;
-                        createOrUpdateIntrospectionOutputFile(schemaText, format, introspectionSourceFile, schemaPath);
-                    } catch (Exception e) {
-                        final Notification notification = new Notification(
-                            GraphQLNotificationUtil.NOTIFICATION_GROUP_ID,
-                            GraphQLBundle.message("graphql.notification.introspection.error.title"),
-                            GraphQLBundle.message("graphql.notification.introspection.error.body", GraphQLNotificationUtil.formatExceptionMessage(e)),
-                            NotificationType.WARNING
-                        ).addAction(retry).setImportant(true);
-
-                        GraphQLNotificationUtil.addRetryFailedSchemaIntrospectionAction(notification, graphQLSettings, e,
-                            () -> performIntrospectionQueryAndUpdateSchemaPathFile(endpoint, schemaPath, introspectionSourceFile));
-                        addShowResponseTextAction(notification, responseJson);
-                        addIntrospectionStackTraceAction(notification, e);
-
-                        Notifications.Bus.notify(notification, myProject);
-                    }
-                });
+                responseJson = ObjectUtils.coalesce(method.getResponseBodyAsString(), "");
             } catch (IOException e) {
-                GraphQLNotificationUtil.showRequestExceptionNotification(retry, url, GraphQLNotificationUtil.formatExceptionMessage(e), NotificationType.WARNING, myProject);
+                GraphQLNotificationUtil.showGraphQLRequestErrorNotification(retry, url, e, NotificationType.WARNING, myProject);
+                return;
             }
+
+            Map<String, Object> introspection;
+            try {
+                introspection = parseIntrospectionJson(responseJson);
+                if (getErrorCount(introspection) > 0) {
+                    JSGraphQLLanguageUIProjectService.getService(myProject).showQueryResult(responseJson);
+                }
+            } catch (JsonSyntaxException exception) {
+                handleIntrospectionError(exception, GraphQLBundle.message("graphql.notification.introspection.parse.error"), responseJson);
+                return;
+            }
+
+            IntrospectionOutputFormat format = schemaPath.endsWith(".json") ? IntrospectionOutputFormat.JSON : IntrospectionOutputFormat.SDL;
+            String schemaText;
+            try {
+                // always try to print the schema to validate it since that will be done in schema discovery of the JSON anyway
+                final String schemaAsSDL = printIntrospectionAsGraphQL(introspection);
+                schemaText = format == IntrospectionOutputFormat.SDL ? schemaAsSDL : responseJson;
+            } catch (Exception exception) {
+                handleIntrospectionError(exception, null, responseJson);
+                return;
+            }
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                try {
+                    createOrUpdateIntrospectionOutputFile(schemaText, format, introspectionSourceFile, schemaPath);
+                } catch (Exception e) {
+                    handleIntrospectionError(e, null, responseJson);
+                }
+            });
+        }
+
+        private int getErrorCount(@NotNull Map<String, Object> introspection) {
+            Object errors = introspection.get("errors");
+            return errors instanceof Collection ? ((Collection<?>) errors).size() : 0;
+        }
+
+        private void handleIntrospectionError(@NotNull Exception e,
+                                              @Nullable String content,
+                                              @NotNull String responseJson) {
+            String body = content != null
+                ? content
+                : GraphQLBundle.message("graphql.notification.introspection.error.body", GraphQLNotificationUtil.formatExceptionMessage(e));
+
+            Notification notification = new Notification(
+                GraphQLNotificationUtil.NOTIFICATION_GROUP_ID,
+                GraphQLBundle.message("graphql.notification.introspection.error.title"),
+                body,
+                NotificationType.WARNING
+            ).addAction(retry).setImportant(true);
+
+            GraphQLNotificationUtil.addRetryFailedSchemaIntrospectionAction(notification, graphQLSettings, e,
+                () -> performIntrospectionQueryAndUpdateSchemaPathFile(endpoint, schemaPath, introspectionSourceFile));
+            addIntrospectionStackTraceAction(notification, e);
+
+            Notifications.Bus.notify(notification, myProject);
+
+            JSGraphQLLanguageUIProjectService.getService(myProject).showQueryResult(responseJson);
         }
     }
 }

--- a/src/main/com/intellij/lang/jsgraphql/ide/notifications/GraphQLNotificationUtil.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/notifications/GraphQLNotificationUtil.java
@@ -42,20 +42,19 @@ public class GraphQLNotificationUtil {
         Notifications.Bus.notify(notification);
     }
 
-    public static void showRequestExceptionNotification(@NotNull NotificationAction retry,
-                                                        @NotNull String url,
-                                                        @NotNull String error,
-                                                        @NotNull NotificationType notificationType,
-                                                        @NotNull Project project) {
-        Notifications.Bus.notify(
-            new Notification(
-                NOTIFICATION_GROUP_ID,
-                GraphQLBundle.message("graphql.notification.error.title"),
-                url + ": " + error,
-                notificationType
-            ).addAction(retry),
-            project
-        );
+    public static void showGraphQLRequestErrorNotification(@NotNull NotificationAction retry,
+                                                           @NotNull String url,
+                                                           @NotNull Exception error,
+                                                           @NotNull NotificationType notificationType,
+                                                           @NotNull Project project) {
+        Notification notification = new Notification(
+            NOTIFICATION_GROUP_ID,
+            GraphQLBundle.message("graphql.notification.error.title"),
+            url + ": " + GraphQLNotificationUtil.formatExceptionMessage(error),
+            notificationType
+        ).addAction(retry);
+
+        Notifications.Bus.notify(notification, project);
     }
 
     public static void addRetryFailedSchemaIntrospectionAction(@NotNull Notification notification,

--- a/src/main/com/intellij/lang/jsgraphql/schema/GraphQLRegistryProvider.java
+++ b/src/main/com/intellij/lang/jsgraphql/schema/GraphQLRegistryProvider.java
@@ -162,7 +162,7 @@ public class GraphQLRegistryProvider implements Disposable {
                     if (psiFile != null) {
                         try {
                             synchronized (GRAPHQL_INTROSPECTION_JSON_TO_SDL) {
-                                final String introspectionJsonAsGraphQL = GraphQLIntrospectionService.getInstance(project).printIntrospectionJsonAsGraphQL(psiFile.getText());
+                                final String introspectionJsonAsGraphQL = GraphQLIntrospectionService.getInstance(project).printIntrospectionAsGraphQL(psiFile.getText());
                                 final GraphQLFile currentSDLPsiFile = psiFile.getUserData(GRAPHQL_INTROSPECTION_JSON_TO_SDL);
                                 if (currentSDLPsiFile != null && currentSDLPsiFile.getText().equals(introspectionJsonAsGraphQL)) {
                                     // already have a PSI file that matches the introspection SDL

--- a/src/main/com/intellij/lang/jsgraphql/v1/ide/project/JSGraphQLLanguageUIProjectService.java
+++ b/src/main/com/intellij/lang/jsgraphql/v1/ide/project/JSGraphQLLanguageUIProjectService.java
@@ -473,24 +473,16 @@ public class JSGraphQLLanguageUIProjectService implements Disposable, FileEditor
             .create();
     }
 
-    public enum QueryResultDisplay {
-        ALWAYS,
-        ON_ERRORS_ONLY
-    }
-
-    public void showQueryResult(String jsonResponse, QueryResultDisplay display) {
-        if (fileEditor instanceof TextEditor) {
-            final TextEditor fileEditor = (TextEditor) this.fileEditor;
-            updateQueryResultEditor(jsonResponse, fileEditor, true);
-            if (display == QueryResultDisplay.ON_ERRORS_ONLY) {
-                final Integer errorCount = getErrorCount(jsonResponse);
-                if (errorCount == null || errorCount > 0) {
-                    showQueryResultEditor(fileEditor);
-                }
-            } else {
-                showQueryResultEditor(fileEditor);
-            }
+    public void showQueryResult(@NotNull String jsonResponse) {
+        if (!(fileEditor instanceof TextEditor)) {
+            return;
         }
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            TextEditor textEditor = (TextEditor) fileEditor;
+            updateQueryResultEditor(jsonResponse, textEditor, true);
+            showQueryResultEditor(textEditor);
+        });
     }
 
     private void showQueryResultEditor(TextEditor textEditor) {

--- a/src/test/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionServiceTest.java
+++ b/src/test/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionServiceTest.java
@@ -1,12 +1,13 @@
 package com.intellij.lang.jsgraphql.ide.editor;
 
-import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class GraphQLIntrospectionServiceTest extends BasePlatformTestCase {
 
@@ -40,8 +41,8 @@ public class GraphQLIntrospectionServiceTest extends BasePlatformTestCase {
 
     private void doTest(@NotNull String source, @NotNull String expected) {
         myFixture.configureByText(
-                "result.graphql",
-                new GraphQLIntrospectionService(getProject()).printIntrospectionJsonAsGraphQL(readSchemaJson(source))
+            "result.graphql",
+            new GraphQLIntrospectionService(getProject()).printIntrospectionAsGraphQL(Objects.requireNonNull(readSchemaJson(source)))
         );
         myFixture.checkResultByFile(expected);
     }
@@ -49,7 +50,7 @@ public class GraphQLIntrospectionServiceTest extends BasePlatformTestCase {
     @Nullable
     private String readSchemaJson(@NotNull String path) {
         try {
-            return VfsUtil.loadText(myFixture.copyFileToProject(path));
+            return VfsUtilCore.loadText(myFixture.copyFileToProject(path));
         } catch (IOException e) {
             return null;
         }


### PR DESCRIPTION
1. Moved the process of building the introspection scheme from the EDT. For example, introspection of the GitHub API schema took a long time and completely hanged UI.
2. Introspection schema parsed twice because of this method `com.intellij.lang.jsgraphql.v1.ide.project.JSGraphQLLanguageUIProjectService#getErrorCount`, it also affected performance of the github introspection.
3. Show query editor with a response in more cases. For example, it wasn't shown when no `data` property exists in the response. But this situation is possible, for example, when you try to fetch GitHub schema without an access token and it's can be unintuitive for a new user where to find the reason of an error.