### PR TITLE
Try to show deprecated filed in UI

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/GraphQLSyntaxAnnotator.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/GraphQLSyntaxAnnotator.java
@@ -12,6 +12,7 @@ import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.jsgraphql.psi.*;
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.editor.colors.CodeInsightColors;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.psi.PsiElement;
@@ -76,6 +77,9 @@ public class GraphQLSyntaxAnnotator implements Annotator {
 
             @Override
             public void visitField(@NotNull GraphQLField field) {
+                if (field.isDeprecated()) {
+                    applyTextAttributes(field.getNameIdentifier(), CodeInsightColors.DEPRECATED_ATTRIBUTES);
+                }
                 applyTextAttributes(field.getNameIdentifier(), FIELD_NAME);
                 super.visitField(field);
             }


### PR DESCRIPTION
Hello and thanks for this essential IntelliJ plugin!

I though it will be easier to add this feature, but I don't have experiences in plugin development et my java skills are very poor, so I didn't found how to get the referenced node (if it exists) and check for the deprecated directive. 

Or maybe it should be handle with GraphQLSyntaxHighlighter ?

Thanks in advance for your advices