### PR TITLE
Fixes caret listener causing an exception (#397)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -64,6 +64,7 @@
     <projectService serviceImplementation="com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService" />
     <projectService serviceInterface="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigGlobMatcher" serviceImplementation="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigGlobMatcherImpl" />
     <projectService serviceImplementation="com.intellij.lang.jsgraphql.ide.GraphQLRelayModernAnnotationFilter" />
+    <projectService serviceImplementation="com.intellij.lang.jsgraphql.v1.ide.editor.JSGraphQLQueryContextCaretListener" />
 
     <!-- Indexing -->
     <fileBasedIndex implementation="com.intellij.lang.jsgraphql.ide.project.indexing.GraphQLIdentifierIndex" />
@@ -73,7 +74,6 @@
     <postStartupActivity implementation="com.intellij.lang.jsgraphql.endpoint.ide.startup.GraphQLStartupActivity" />
     <postStartupActivity implementation="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigProjectStartupActivity" />
     <postStartupActivity implementation="com.intellij.lang.jsgraphql.ide.project.relay.GraphQLRelayModernEnableStartupActivity" />
-    <postStartupActivity implementation="com.intellij.lang.jsgraphql.v1.ide.editor.JSGraphQLQueryContextCaretListener" />
 
     <!-- Syntax and error highlighting -->
     <lang.syntaxHighlighterFactory language="GraphQL" implementationClass="com.intellij.lang.jsgraphql.ide.GraphQLSyntaxHighlighterFactory"/>


### PR DESCRIPTION
Resolves #397, but unfortunately this assertion still fails under certain circumstances which I can't consistently reproduce. One more possible stack trace:

```
"Alarm Pool@4266" prio=4 tid=0x21 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at com.intellij.psi.impl.file.impl.FileManagerImpl.checkHasNoOtherPsi(FileManagerImpl.java:205)
	  at com.intellij.psi.impl.file.impl.FileManagerImpl.findViewProvider(FileManagerImpl.java:194)
	  at com.intellij.psi.impl.file.impl.FileManagerImpl.findFile(FileManagerImpl.java:368)
	  at com.intellij.psi.impl.PsiManagerImpl.findFile(PsiManagerImpl.java:154)
	  at com.intellij.swagger.providers.SwJsonSchemaFileProviderFactory$getProviders$1.invoke(SwJsonSchemaFileProviderFactory.kt:30)
	  at com.intellij.swagger.providers.SwJsonSchemaFileProviderFactory$getProviders$1.invoke(SwJsonSchemaFileProviderFactory.kt:17)
	  at com.intellij.swagger.providers.SpecificationJsonSchemaFileProvider$isAvailable$1.compute(SwJsonSchemaFileProviderFactory.kt:51)
	  at com.intellij.swagger.providers.SpecificationJsonSchemaFileProvider$isAvailable$1.compute(SwJsonSchemaFileProviderFactory.kt:45)
	  at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:876)
	  at com.intellij.swagger.providers.SpecificationJsonSchemaFileProvider.isAvailable(SwJsonSchemaFileProviderFactory.kt:51)
	  at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.isProviderAvailable(JsonSchemaServiceImpl.java:429)
	  at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.getProvidersForFile(JsonSchemaServiceImpl.java:243)
	  at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.getSchemasForFile(JsonSchemaServiceImpl.java:179)
	  at com.jetbrains.jsonSchema.JsonSchemaVfsListener$MyUpdater.lambda$new$6(JsonSchemaVfsListener.java:100)
	  at com.jetbrains.jsonSchema.JsonSchemaVfsListener$MyUpdater$$Lambda$3708.930889482.accept(Unknown Source:-1)
	  at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	  at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	  at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	  at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	  at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	  at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	  at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	  at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	  at com.jetbrains.jsonSchema.JsonSchemaVfsListener$MyUpdater.lambda$new$7(JsonSchemaVfsListener.java:99)
	  at com.jetbrains.jsonSchema.JsonSchemaVfsListener$MyUpdater$$Lambda$3003.480026259.run(Unknown Source:-1)
	  at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:178)
	  at com.intellij.openapi.progress.impl.CoreProgressManager$$Lambda$342.1549759230.run(Unknown Source:-1)
	  at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:658)
	  at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:610)
	  at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
	  at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:165)
	  at com.intellij.openapi.progress.util.BackgroundTaskUtil.runUnderDisposeAwareIndicator(BackgroundTaskUtil.java:254)
	  at com.intellij.openapi.util.ZipperUpdater$1.run(ZipperUpdater.java:52)
	  at com.intellij.util.concurrency.QueueProcessor.runSafely(QueueProcessor.java:238)
	  at com.intellij.util.Alarm$Request.runSafely(Alarm.java:370)
	  at com.intellij.util.Alarm$Request.run(Alarm.java:356)
	  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	  at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	  at com.intellij.util.concurrency.SchedulingWrapper$MyScheduledFutureTask.run(SchedulingWrapper.java:220)
	  at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:216)
	  at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:27)
	  at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:195)
	  at com.intellij.util.concurrency.BoundedTaskExecutor$1$$Lambda$485.1963586501.run(Unknown Source:-1)
	  at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:208)
	  at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:184)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	  at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	  at java.security.AccessController.doPrivileged(AccessController.java:-1)
	  at java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	  at java.lang.Thread.run(Thread.java:834)
```