### PR TITLE
feat: Added inline/preloadable

### DIFF
--- a/resources/META-INF/relay modern directives schema.graphql
+++ b/resources/META-INF/relay modern directives schema.graphql
@@ -37,6 +37,8 @@ directive @relay(
     mask: Boolean
 ) on FRAGMENT_DEFINITION | FRAGMENT_SPREAD
 
+directive @inline on FRAGMENT_DEFINITION
+
 directive @match on FIELD
 
 directive @module(
@@ -57,3 +59,5 @@ directive @stream(
     initial_count: Int!
     if: Boolean = true
 ) on FIELD
+
+@preloadable on QUERY


### PR DESCRIPTION
`@inline` has been missing for months, so adding that in. As well as add in an up-and-coming `@preloadable` (https://github.com/facebook/relay/blob/00813fec70d9015a2d90a4ea2df63a005cfaed3d/compiler/crates/relay-transforms/src/generate_preloadable_metadata.rs#L19)