### PR TITLE
Load .env variable from different types of .env file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GraphQL language support for WebStorm, IntelliJ IDEA and other IDEs based on the
 - Syntax highlighting, code-formatting, folding, commenter, and brace-matching
 - 'Find Usages' and 'Go to Declaration' for schema types, fields, and fragments
 - 'Structure view' to navigate GraphQL files
-- Load variables from .env files
+- Load variables from .env files. Supported file names: `.env.local`,`.env.development.local`,`.env.development`,`.env`
 
 ## Documentation
 

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
@@ -145,11 +145,9 @@ public class GraphQLConfigVariableAwareEndpoint {
         if (configFile != null) {
             VirtualFile parentDir = configFile.getParent();
             if (parentDir != null) {
-                DotenvBuilder dotenvBuilder = getDotenvBuilder(parentDir.getPath());
-
                 String filename = getFileName(parentDir);
                 if (filename != null) {
-                    dotenv = dotenvBuilder.filename(filename).load();
+                    dotenv = getDotenvBuilder(parentDir.getPath()).filename(filename).load();
                     varValue = dotenv.get(varName);
                 }
             }
@@ -158,13 +156,11 @@ public class GraphQLConfigVariableAwareEndpoint {
         // If that didn't resolve try to load the env file from the root of the project
         String projectBasePath = project.getBasePath();
         if (varValue == null && projectBasePath != null) {
-            DotenvBuilder dotenvBuilder = getDotenvBuilder(projectBasePath);
-
             VirtualFile projectDir = ProjectUtil.guessProjectDir(project);
             if (projectDir != null) {
                 String filename = getFileName(projectDir);
                 if (filename != null) {
-                    dotenv = dotenvBuilder.filename(filename).load();
+                    dotenv = getDotenvBuilder(projectBasePath).filename(filename).load();
                     varValue = dotenv.get(varName);
                 }
             }

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
@@ -14,16 +14,20 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import io.github.cdimascio.dotenv.Dotenv;
+import io.github.cdimascio.dotenv.DotenvBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -141,30 +145,61 @@ public class GraphQLConfigVariableAwareEndpoint {
         if (configFile != null) {
             VirtualFile parentDir = configFile.getParent();
             if (parentDir != null) {
-                dotenv = Dotenv
-                    .configure()
-                    .directory(parentDir.getPath())
-                    .ignoreIfMalformed()
-                    .ignoreIfMissing()
-                    .load();
+                DotenvBuilder dotenvBuilder = getDotenvBuilder(parentDir.getPath());
 
-                varValue = dotenv.get(varName);
+                String filename = getFileName(parentDir);
+                if (filename != null) {
+                    dotenv = dotenvBuilder.filename(filename).load();
+                    varValue = dotenv.get(varName);
+                }
             }
         }
 
         // If that didn't resolve try to load the env file from the root of the project
         String projectBasePath = project.getBasePath();
         if (varValue == null && projectBasePath != null) {
-            dotenv = Dotenv
-                .configure()
-                .directory(projectBasePath)
-                .ignoreIfMalformed()
-                .ignoreIfMissing()
-                .load();
+            DotenvBuilder dotenvBuilder = getDotenvBuilder(projectBasePath);
 
-            varValue = dotenv.get(varName);
+            VirtualFile projectDir = ProjectUtil.guessProjectDir(project);
+            if (projectDir != null) {
+                String filename = getFileName(projectDir);
+                if (filename != null) {
+                    dotenv = dotenvBuilder.filename(filename).load();
+                    varValue = dotenv.get(varName);
+                }
+            }
         }
         return varValue;
+    }
+
+    private DotenvBuilder getDotenvBuilder(String path) {
+        return Dotenv
+            .configure()
+            .directory(path)
+            .ignoreIfMalformed()
+            .ignoreIfMissing();
+    }
+
+    private String getFileName(VirtualFile dirMaybeContainingEnvFile) {
+        if (!dirMaybeContainingEnvFile.isDirectory())
+            return null;
+
+        // List of supported names for .env files in prioritized order
+        List<String> supportedEnvFiles = Arrays.asList(
+            ".env.local",
+            ".env.development.local",
+            ".env.development",
+            ".env");
+
+        // Look through the supported names and return the first we find
+        for (String envFileName : supportedEnvFiles) {
+            VirtualFile maybeEnvFile = dirMaybeContainingEnvFile.findChild(envFileName);
+            if (maybeEnvFile != null && maybeEnvFile.exists()) {
+                return envFileName;
+            }
+        }
+
+        return null;
     }
 
     static class VariableDialog extends DialogWrapper {

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigVariableAwareEndpoint.java
@@ -160,7 +160,7 @@ public class GraphQLConfigVariableAwareEndpoint {
             if (projectDir != null) {
                 String filename = getFileName(projectDir);
                 if (filename != null) {
-                    dotenv = getDotenvBuilder(projectBasePath).filename(filename).load();
+                    dotenv = getDotenvBuilder(projectDir.getPath()).filename(filename).load();
                     varValue = dotenv.get(varName);
                 }
             }


### PR DESCRIPTION
Hi @vepanimas here is a PR that enables [the request](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/issues/285#issuecomment-813414997) for loading env variables from multiple .env file names. Let me know what you think.