### PR TITLE
Add support for Apollo Federation schema specification.

### DIFF
--- a/resources/META-INF/federation specification schema.graphql
+++ b/resources/META-INF/federation specification schema.graphql
@@ -1,0 +1,25 @@
+# https://www.apollographql.com/docs/federation/federation-spec/#federation-schema-specification
+scalar _Any
+scalar _FieldSet
+
+# a union of all types that use the @key directive
+# noinspection GraphQLEmptyType
+union _Entity
+
+type _Service {
+    sdl: String
+}
+
+extend type Query {
+    _entities(representations: [_Any!]!): [_Entity]!
+    _service: _Service!
+}
+
+directive @external on FIELD_DEFINITION
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+
+# `repeatable` is technically not part of the spec, but is added here so that multiple `type Query @extends { ... }`
+# definitions from different DGS schemas would pass validation
+directive @extends repeatable on OBJECT | INTERFACE

--- a/src/main/com/intellij/lang/jsgraphql/GraphQLSettings.java
+++ b/src/main/com/intellij/lang/jsgraphql/GraphQLSettings.java
@@ -61,6 +61,14 @@ public class GraphQLSettings implements PersistentStateComponent<GraphQLSettings
         myState.enableRelayModernFrameworkSupport = enableRelayModernFrameworkSupport;
     }
 
+    public boolean isFederationSupportEnabled() {
+        return myState.enableFederationSupport;
+    }
+
+    public void setFederationSupportEnabled(boolean enableFederationSupport) {
+        myState.enableFederationSupport = enableFederationSupport;
+    }
+
     public boolean isEnableIntrospectionDefaultValues() {
         return myState.enableIntrospectionDefaultValues;
     }
@@ -91,6 +99,7 @@ public class GraphQLSettings implements PersistentStateComponent<GraphQLSettings
         public boolean enableIntrospectionDefaultValues = true;
         public boolean openEditorWithIntrospectionResult = true;
         public boolean enableRelayModernFrameworkSupport;
+        public boolean enableFederationSupport = false;
     }
 }
 

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
@@ -93,7 +93,7 @@ public class GraphQLPsiSearchHelper implements Disposable {
         GraphQLSettings settings = GraphQLSettings.getSettings(project);
         myBuiltInSchemaScopes = builtInSchemaScope
             .union(new ConditionalGlobalSearchScope(builtInRelaySchemaScope, settings::isRelaySupportEnabled))
-            .union(builtInFederationSchemaScope)
+            .union(new ConditionalGlobalSearchScope(builtInFederationSchemaScope, settings::isFederationSupportEnabled))
             .union(defaultProjectFileScope);
 
         final FileType[] searchScopeFileTypes = GraphQLFindUsagesUtil.getService().getIncludedFileTypes().toArray(FileType.EMPTY_ARRAY);

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
@@ -87,10 +87,13 @@ public class GraphQLPsiSearchHelper implements Disposable {
             GlobalSearchScope.fileScope(project, myExternalDefinitionsProvider.getBuiltInSchema().getVirtualFile());
         GlobalSearchScope builtInRelaySchemaScope =
             GlobalSearchScope.fileScope(project, myExternalDefinitionsProvider.getRelayModernDirectivesSchema().getVirtualFile());
+        GlobalSearchScope builtInFederationSchemaScope =
+            GlobalSearchScope.fileScope(project, myExternalDefinitionsProvider.getBuiltInFederationSchema().getVirtualFile());
 
         GraphQLSettings settings = GraphQLSettings.getSettings(project);
         myBuiltInSchemaScopes = builtInSchemaScope
             .union(new ConditionalGlobalSearchScope(builtInRelaySchemaScope, settings::isRelaySupportEnabled))
+            .union(builtInFederationSchemaScope)
             .union(defaultProjectFileScope);
 
         final FileType[] searchScopeFileTypes = GraphQLFindUsagesUtil.getService().getIncludedFileTypes().toArray(FileType.EMPTY_ARRAY);
@@ -339,6 +342,9 @@ public class GraphQLPsiSearchHelper implements Disposable {
             // spec schema
             myExternalDefinitionsProvider.getBuiltInSchema().accept(builtInFileVisitor);
 
+            // federation spec schema
+            myExternalDefinitionsProvider.getBuiltInFederationSchema().accept(builtInFileVisitor);
+
             // relay schema if enabled
             final PsiFile relayModernDirectivesSchema = myExternalDefinitionsProvider.getRelayModernDirectivesSchema();
             if (schemaScope.contains(relayModernDirectivesSchema.getVirtualFile())) {
@@ -382,6 +388,10 @@ public class GraphQLPsiSearchHelper implements Disposable {
         final PsiFile relayModernDirectivesSchema = myExternalDefinitionsProvider.getRelayModernDirectivesSchema();
         if (schemaScope.contains(relayModernDirectivesSchema.getVirtualFile())) {
             processor.process(relayModernDirectivesSchema);
+        }
+        final PsiFile federationSpecSchema = myExternalDefinitionsProvider.getBuiltInFederationSchema();
+        if (schemaScope.contains(federationSpecSchema.getVirtualFile())) {
+            processor.process(federationSpecSchema);
         }
     }
 

--- a/src/main/com/intellij/lang/jsgraphql/ide/references/GraphQLReferenceService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/references/GraphQLReferenceService.java
@@ -230,6 +230,19 @@ public class GraphQLReferenceService implements Disposable {
                     }
                 });
             }
+            if (name.startsWith("_")) {
+                // __typename or introspection fields _entities and _service which extends the query root type
+                myExternalTypeDefinitionsProvider.getBuiltInFederationSchema().accept(new PsiRecursiveElementVisitor() {
+                    @Override
+                    public void visitElement(final @NotNull PsiElement schemaElement) {
+                        if (schemaElement instanceof GraphQLReferenceMixin && schemaElement.getText().equals(name)) {
+                            reference.set(createReference(element, schemaElement));
+                            return;
+                        }
+                        super.visitElement(schemaElement);
+                    }
+                });
+            }
             final GraphQLTypeScopeProvider typeScopeProvider = PsiTreeUtil.getParentOfType(field, GraphQLTypeScopeProvider.class);
             if (reference.isNull() && typeScopeProvider != null) {
                 GraphQLType typeScope = typeScopeProvider.getTypeScope();

--- a/src/main/com/intellij/lang/jsgraphql/schema/GraphQLExternalTypeDefinitionsProvider.java
+++ b/src/main/com/intellij/lang/jsgraphql/schema/GraphQLExternalTypeDefinitionsProvider.java
@@ -23,6 +23,7 @@ public class GraphQLExternalTypeDefinitionsProvider {
 
     private static final String BUILT_IN_SCHEMA = "BUILT_IN";
     private static final String RELAY = "RELAY";
+    private static final String FEDERATION_SCHEMA = "FEDERATION";
 
     private final Project myProject;
     private final Map<String, PsiFile> myDefinitionFiles = new ConcurrentHashMap<>();
@@ -44,6 +45,18 @@ public class GraphQLExternalTypeDefinitionsProvider {
             "graphql specification schema.graphql",
             "GraphQL Specification Schema",
             BUILT_IN_SCHEMA
+        );
+    }
+
+    /**
+     * Gets the built-in Schema that all endpoints support, including the introspection types, fields, directives and default scalars.
+     */
+    @NotNull
+    public PsiFile getBuiltInFederationSchema() {
+        return getPsiFileFromResources(
+            "federation specification schema.graphql",
+            "GraphQL Federation Specification Schema",
+            FEDERATION_SCHEMA
         );
     }
 

--- a/src/main/com/intellij/lang/jsgraphql/ui/GraphQLProjectSettingsForm.form
+++ b/src/main/com/intellij/lang/jsgraphql/ui/GraphQLProjectSettingsForm.form
@@ -59,7 +59,7 @@
           </component>
         </children>
       </grid>
-      <grid id="ed16d" binding="frameworksPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="ed16d" binding="frameworksPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -75,6 +75,14 @@
               <enabled value="true"/>
               <text resource-bundle="messages/GraphQLMessages" key="graphql.settings.frameworks.relay.label"/>
               <toolTipText resource-bundle="messages/GraphQLMessages" key="graphql.settings.frameworks.relay.tooltip"/>
+            </properties>
+          </component>
+          <component id="c84dc" class="javax.swing.JCheckBox" binding="enableFederation">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Federation"/>
             </properties>
           </component>
         </children>

--- a/src/main/com/intellij/lang/jsgraphql/ui/GraphQLProjectSettingsForm.java
+++ b/src/main/com/intellij/lang/jsgraphql/ui/GraphQLProjectSettingsForm.java
@@ -27,8 +27,10 @@ public class GraphQLProjectSettingsForm {
     private JPanel introspectionPanel;
     private ExpandableTextField introspectionQueryTextField;
     private JCheckBox enableIntrospectionDefaultValues;
+
     private JPanel frameworksPanel;
     private JCheckBox enableRelay;
+    private JCheckBox enableFederation;
     private JCheckBox openEditorWithIntrospectionResult;
 
     private GraphQLSettings mySettings;
@@ -52,22 +54,27 @@ public class GraphQLProjectSettingsForm {
     void apply() {
         mySettings.setIntrospectionQuery(introspectionQueryTextField.getText());
         mySettings.setRelaySupportEnabled(enableRelay.isSelected());
+        mySettings.setFederationSupportEnabled(enableFederation.isSelected());
         mySettings.setEnableIntrospectionDefaultValues(enableIntrospectionDefaultValues.isSelected());
         mySettings.setOpenEditorWithIntrospectionResult(openEditorWithIntrospectionResult.isSelected());
+
     }
 
     void reset() {
         introspectionQueryTextField.setText(mySettings.getIntrospectionQuery());
         enableIntrospectionDefaultValues.setSelected(mySettings.isEnableIntrospectionDefaultValues());
         enableRelay.setSelected(mySettings.isRelaySupportEnabled());
+        enableFederation.setSelected(mySettings.isFederationSupportEnabled());
         openEditorWithIntrospectionResult.setSelected(mySettings.isOpenEditorWithIntrospectionResult());
     }
 
     boolean isModified() {
         return !Objects.equals(mySettings.getIntrospectionQuery(), introspectionQueryTextField.getText()) ||
             mySettings.isRelaySupportEnabled() != enableRelay.isSelected() ||
+            mySettings.isFederationSupportEnabled() != enableFederation.isSelected() ||
             mySettings.isEnableIntrospectionDefaultValues() != enableIntrospectionDefaultValues.isSelected() ||
             mySettings.isOpenEditorWithIntrospectionResult() != openEditorWithIntrospectionResult.isSelected();
+
     }
 
     {


### PR DESCRIPTION
At Netflix, we have many federated graphs built using the Domain Graph Service Framework (DGS) to build GraphQL services. This is implemented according to Apollo's Federation Spec(https://www.apollographql.com/docs/federation/federation-spec/#federation-schema-specification). This PR adds support for the plugin to recognize federation specific schema types and directives.

This is part of a larger effort to improve the developer experience for GraphQL, similar to this PR(https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/pull/498)