### PR TITLE
Support ssl config with certificates in http client for introspection.

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionSSLBuilder.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/editor/GraphQLIntrospectionSSLBuilder.java
@@ -1,0 +1,94 @@
+package com.intellij.lang.jsgraphql.ide.editor;
+
+import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigCertificate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collection;
+
+public class GraphQLIntrospectionSSLBuilder {
+    @NotNull
+    public static KeyStore makeKeyStore(final Path certPath, final Path keyPath, final GraphQLConfigCertificate.Encoding format) throws UnsupportedEncodingException {
+        CertificateFactory certificateFactory;
+        try {
+            certificateFactory = CertificateFactory.getInstance("X509");
+        } catch (CertificateException e) {
+            throw new IllegalStateException(e);
+        }
+
+        java.security.cert.Certificate[] certChain;
+        try (InputStream inputStream = Files.newInputStream(certPath)) {
+            Collection<? extends Certificate> certCollection = certificateFactory.generateCertificates(inputStream);
+            certChain = certCollection.toArray(new java.security.cert.Certificate[certCollection.size()]);
+        } catch (CertificateException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // We only support PEM format for now
+        if (format != GraphQLConfigCertificate.Encoding.PEM) {
+            throw new UnsupportedEncodingException("Format needs to be specified as PEM");
+        }
+
+        KeyStore keyStore;
+        try {
+            PrivateKey privateKey = generatePEMPrivateKey(keyPath);
+            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            // Not supporting keystore and key passwords yet
+            keyStore.load(null, null);
+            keyStore.setKeyEntry("1", privateKey, null, certChain);
+        } catch (NoSuchAlgorithmException | KeyStoreException | IOException | CertificateException e) {
+            throw new IllegalStateException(e);
+        }
+        return keyStore;
+    }
+
+    @Nullable
+    private static PrivateKey generatePEMPrivateKey(final Path keyPath) throws IOException {
+
+        String key = new String(Files.readAllBytes(keyPath), Charset.defaultCharset());
+        String privateKeyPEM = key
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replaceAll(System.lineSeparator(), "")
+            .replace("-----END PRIVATE KEY-----", "");
+
+        byte[] decoded = Base64.getDecoder().decode(privateKeyPEM);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+        PrivateKey privateKey;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            privateKey = kf.generatePrivate(keySpec);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        } catch (InvalidKeySpecException e) {
+            try {
+                KeyFactory kf = KeyFactory.getInstance("EC");
+                privateKey = kf.generatePrivate(keySpec);
+            } catch (InvalidKeySpecException e1) {
+                try {
+                    KeyFactory kf = KeyFactory.getInstance("DSA");
+                    privateKey = kf.generatePrivate(keySpec);
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException e2) {
+                    throw new RuntimeException(e2);
+                }
+            } catch (NoSuchAlgorithmException e1) {
+                throw new IllegalStateException(e1);
+            }
+        }
+
+        return privateKey;
+    }
+}

--- a/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionSSLBuilder.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionSSLBuilder.java
@@ -1,4 +1,4 @@
-package com.intellij.lang.jsgraphql.ide.editor;
+package com.intellij.lang.jsgraphql.ide.introspection;
 
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigCertificate;
 import org.jetbrains.annotations.NotNull;
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.*;
@@ -22,7 +21,8 @@ import java.util.Collection;
 
 public class GraphQLIntrospectionSSLBuilder {
     @NotNull
-    public static KeyStore makeKeyStore(final Path certPath, final Path keyPath, final GraphQLConfigCertificate.Encoding format) throws UnsupportedEncodingException {
+    public static KeyStore makeKeyStore(final Path certPath, final Path keyPath, final GraphQLConfigCertificate.Encoding format)
+        throws UnsupportedEncodingException {
         CertificateFactory certificateFactory;
         try {
             certificateFactory = CertificateFactory.getInstance("X509");
@@ -33,7 +33,7 @@ public class GraphQLIntrospectionSSLBuilder {
         java.security.cert.Certificate[] certChain;
         try (InputStream inputStream = Files.newInputStream(certPath)) {
             Collection<? extends Certificate> certCollection = certificateFactory.generateCertificates(inputStream);
-            certChain = certCollection.toArray(new java.security.cert.Certificate[certCollection.size()]);
+            certChain = certCollection.toArray(new Certificate[0]);
         } catch (CertificateException | IOException e) {
             throw new RuntimeException(e);
         }
@@ -59,7 +59,7 @@ public class GraphQLIntrospectionSSLBuilder {
     @Nullable
     private static PrivateKey generatePEMPrivateKey(final Path keyPath) throws IOException {
 
-        String key = new String(Files.readAllBytes(keyPath), Charset.defaultCharset());
+        String key = Files.readString(keyPath, Charset.defaultCharset());
         String privateKeyPEM = key
             .replace("-----BEGIN PRIVATE KEY-----", "")
             .replaceAll(System.lineSeparator(), "")

--- a/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
@@ -226,7 +226,7 @@ public class GraphQLIntrospectionService implements Disposable {
     }
 
     @NotNull
-    public CloseableHttpClient createHttpClient(GraphQLConfigSecurity sslConfig) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, IOException, UnrecoverableKeyException, CertificateException {
+    public CloseableHttpClient createHttpClient(@Nullable GraphQLConfigSecurity sslConfig) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, IOException, UnrecoverableKeyException, CertificateException {
         HttpClientBuilder builder = HttpClients.custom();
         builder.setRedirectStrategy(LaxRedirectStrategy.INSTANCE);
 

--- a/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
@@ -196,9 +196,7 @@ public class GraphQLIntrospectionService implements Disposable {
         builder.setRedirectStrategy(LaxRedirectStrategy.INSTANCE);
 
         if (PropertiesComponent.getInstance(myProject).isTrueValue(GRAPHQL_TRUST_ALL_HOSTS)) {
-            Map<VirtualFile, GraphQLConfigData> configEntries =
-                GraphQLConfigManager.getService(myProject).getConfigurationsByPath();
-            GraphQLConfigSecurity sslConfig = configEntries.get(myProject.getBaseDir()).sslConfiguration;
+            GraphQLConfigSecurity sslConfig = GraphQLConfigManager.getService(myProject).getSSLConfiguration();
             if (sslConfig != null) {
                 if (sslConfig.clientCertificate.path == null || sslConfig.clientCertificateKey.path == null) {
                     throw new RuntimeException("Path needs to be specified for the key and certificate");

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLUIProjectService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLUIProjectService.java
@@ -359,7 +359,7 @@ public class GraphQLUIProjectService implements Disposable, FileEditorManagerLis
     private void runQuery(Editor editor, VirtualFile virtualFile, GraphQLQueryContext context, String url, HttpPost request) {
         GraphQLIntrospectionService introspectionService = GraphQLIntrospectionService.getInstance(myProject);
         try {
-            VirtualFile configFile = GraphQLConfigManager.getService(myProject).getClosestConfigFile(virtualFile).getParent();
+            VirtualFile configFile = GraphQLConfigManager.getService(myProject).getClosestConfigFile(virtualFile);
             GraphQLConfigSecurity sslConfig = introspectionService.getSecurityConfig(configFile);
             try (final CloseableHttpClient httpClient = introspectionService.createHttpClient(sslConfig)) {
                 editor.putUserData(GRAPH_QL_EDITOR_QUERYING, true);

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLUIProjectService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLUIProjectService.java
@@ -27,6 +27,7 @@ import com.intellij.lang.jsgraphql.ide.notifications.GraphQLNotificationUtil;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManager;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigurationListener;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
+import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigSecurity;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigVariableAwareEndpoint;
 import com.intellij.lang.jsgraphql.ide.project.schemastatus.GraphQLEndpointsModel;
 import com.intellij.lang.jsgraphql.ide.project.toolwindow.GraphQLToolWindow;
@@ -358,7 +359,9 @@ public class GraphQLUIProjectService implements Disposable, FileEditorManagerLis
     private void runQuery(Editor editor, VirtualFile virtualFile, GraphQLQueryContext context, String url, HttpPost request) {
         GraphQLIntrospectionService introspectionService = GraphQLIntrospectionService.getInstance(myProject);
         try {
-            try (final CloseableHttpClient httpClient = introspectionService.createHttpClient()) {
+            VirtualFile configFile = GraphQLConfigManager.getService(myProject).getClosestConfigFile(virtualFile).getParent();
+            GraphQLConfigSecurity sslConfig = introspectionService.getSecurityConfig(configFile);
+            try (final CloseableHttpClient httpClient = introspectionService.createHttpClient(sslConfig)) {
                 editor.putUserData(GRAPH_QL_EDITOR_QUERYING, true);
 
                 String responseJson;

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -25,6 +25,7 @@ import com.intellij.lang.jsgraphql.ide.introspection.GraphQLIntrospectionService
 import com.intellij.lang.jsgraphql.ide.notifications.GraphQLNotificationUtil;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigData;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
+import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigSecurity;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLResolvedConfigData;
 import com.intellij.lang.jsgraphql.ide.findUsages.GraphQLFindUsagesUtil;
 import com.intellij.lang.jsgraphql.psi.GraphQLFile;

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -7,6 +7,7 @@
  */
 package com.intellij.lang.jsgraphql.ide.project.graphqlconfig;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -106,6 +107,7 @@ public class GraphQLConfigManager implements Disposable {
     );
 
     public static final String ENDPOINTS_EXTENSION = "endpoints";
+    public static final String SSL_EXTENSION = "sslConfiguration";
 
     public static final String GRAPHQLCONFIG = ".graphqlconfig";
     public static final String GRAPHQLCONFIG_COMMENT = ".graphqlconfig=";
@@ -422,6 +424,18 @@ public class GraphQLConfigManager implements Disposable {
             }
 
             return emptyList;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Nullable
+    public GraphQLConfigSecurity getSSLConfiguration() {
+        try {
+            readLock.lock();
+            Map<VirtualFile, GraphQLConfigData> configEntries = getService(myProject).getConfigurationsByPath();
+            GraphQLConfigSecurity sslConfig = new ObjectMapper().convertValue(configEntries.get(myProject.getBaseDir()).extensions.get(SSL_EXTENSION), GraphQLConfigSecurity.class);
+            return sslConfig;
         } finally {
             readLock.unlock();
         }

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -7,7 +7,6 @@
  */
 package com.intellij.lang.jsgraphql.ide.project.graphqlconfig;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -26,7 +25,6 @@ import com.intellij.lang.jsgraphql.ide.introspection.GraphQLIntrospectionService
 import com.intellij.lang.jsgraphql.ide.notifications.GraphQLNotificationUtil;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigData;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
-import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigSecurity;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLResolvedConfigData;
 import com.intellij.lang.jsgraphql.ide.findUsages.GraphQLFindUsagesUtil;
 import com.intellij.lang.jsgraphql.psi.GraphQLFile;

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -429,18 +429,6 @@ public class GraphQLConfigManager implements Disposable {
         }
     }
 
-    @Nullable
-    public GraphQLConfigSecurity getSSLConfiguration() {
-        try {
-            readLock.lock();
-            Map<VirtualFile, GraphQLConfigData> configEntries = getService(myProject).getConfigurationsByPath();
-            GraphQLConfigSecurity sslConfig = new ObjectMapper().convertValue(configEntries.get(myProject.getBaseDir()).extensions.get(SSL_EXTENSION), GraphQLConfigSecurity.class);
-            return sslConfig;
-        } finally {
-            readLock.unlock();
-        }
-    }
-
     void initialize() {
         final MessageBusConnection connection = myProject.getMessageBus().connect(this);
         connection.subscribe(ProjectTopics.PROJECT_ROOTS, new ModuleRootListener() {

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigCertificate.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigCertificate.java
@@ -1,0 +1,8 @@
+package com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model;
+
+public class GraphQLConfigCertificate {
+    public enum Encoding {PEM}
+
+    public String path;
+    public Encoding format = Encoding.PEM;
+}

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigData.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigData.java
@@ -13,7 +13,5 @@ import java.util.Map;
  * graphql-config root config
  */
 public class GraphQLConfigData extends GraphQLResolvedConfigData {
-
     public Map<String, GraphQLResolvedConfigData> projects;
-
 }

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigSecurity.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLConfigSecurity.java
@@ -1,0 +1,9 @@
+package com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model;
+
+/**
+ * graphql-config security config
+ */
+public class GraphQLConfigSecurity {
+    public GraphQLConfigCertificate clientCertificate;
+    public GraphQLConfigCertificate clientCertificateKey;
+}

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLResolvedConfigData.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLResolvedConfigData.java
@@ -23,6 +23,4 @@ public class GraphQLResolvedConfigData {
     public List<String> excludes;
 
     public Map<String, Object> extensions;
-
-    public GraphQLConfigSecurity sslConfiguration;
 }

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLResolvedConfigData.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/model/GraphQLResolvedConfigData.java
@@ -24,4 +24,5 @@ public class GraphQLResolvedConfigData {
 
     public Map<String, Object> extensions;
 
+    public GraphQLConfigSecurity sslConfiguration;
 }


### PR DESCRIPTION
This PR adds basic functionality for the user to specify ssl config for using ssl certificates to set up authentication for the HttpClient. The is PR does not address all the formats (only PEM and not DER etc.). In addition, there is no support for specifying key store and private key passwords.

```
{
  "name": "Remote Schema",
  "schemaPath": "remote-schema.graphql",
  "sslConfiguration": {
    "clientCertificate": {
      "path": "./certificates/user.crt"
    },
    "clientCertificateKey": {
      "path": "./certificates/user.key",
      "format": "PEM"
    }
  }
}
```