### PR TITLE
operationName for Apollo Federation Gateway #595

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionService.java
@@ -147,7 +147,7 @@ public class GraphQLIntrospectionService implements Disposable {
             final GraphQLSettings graphQLSettings = GraphQLSettings.getSettings(myProject);
             String query = buildIntrospectionQuery(graphQLSettings);
 
-            final String requestJson = "{\"query\":\"" + StringEscapeUtils.escapeJavaScript(query) + "\"}";
+            final String requestJson = "{\"operationName\": \"IntrospectionQuery\", \"query\":\"" + StringEscapeUtils.escapeJavaScript(query) + "\"}";
             HttpPost request = createRequest(endpoint, url, requestJson);
             Task.Backgroundable task = new IntrospectionQueryTask(request, schemaPath, introspectionSourceFile, retry, graphQLSettings, endpoint, url);
             ProgressManager.getInstance().run(task);


### PR DESCRIPTION
Added operationName key to dynamically add query, mutation, or subscription name to data object or anonymous in unnamed

next is to make the data key/value editable to user/opt-in 

not sure if there is already some way built-in to accomplish this, but wanted to setup at least for my company and maybe if generalizable could be useful for others 